### PR TITLE
Introduce terraform-runner

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+docker build -t taskcluster/terraform-runner terraform-runner

--- a/terraform-runner.sh
+++ b/terraform-runner.sh
@@ -1,0 +1,74 @@
+#! /bin/bash -e
+
+docker_image="taskcluster/terraform-runner@sha256:a0bd91de143521d4d87e5b34b2df9093224fd75d53a4ddc089dc73edf3a9c499"
+deployment="$1"
+
+if [ -z "$deployment" ] || [ ! -f terraform-runner.sh ]; then
+    echo "USAGE: ./terraform-runner.sh <deployment>"
+    echo "  NOTE: set \$PASSWORD_STORE_DIR to point to the TC password store."
+    exit 1
+fi
+
+msg() {
+    local level="${1}"
+    shift
+
+    local _esc=$'\033'
+    local normal="$_esc[0m"
+
+    case $level in
+        # don't display debug messages unless DEBUG is set
+        debug) [ -z "$DEBUG" ] && return ;;
+        info) local color="$_esc[0;36m" ;;
+        warning) local color="$_esc[1;33m" ;;
+        error) local color="$_esc[1;31m" ;;
+    esac
+
+    echo "$color${@}$normal"
+}
+
+# the docker image wants to write to the .terraform directory, so
+# make it a link to a directory it can write to.  Note that these
+# directories must be created by the Dockerfile!
+for terraform_dir in install setup; do
+    rm -rf $terraform_dir/.terraform
+    ln -s /home/tf/${terraform_dir}-.terraform $terraform_dir/.terraform
+done
+
+## Build a docker create command-line and execute it
+
+declare -a docker
+docker=(docker run -ti --rm)
+
+# mount a named volume (named after the deployment) at $HOME; this stores
+# all of the dotfiles containing credentials, as well as the terraform modules
+# (via the symlinks added above)
+docker+=(-v "${deployment}-credentials:/home/tf")
+msg warning "CAUTION: docker volume ${deployment}-credentials contains sensitive secrets"
+
+# Mount the current directory (the root of the repo) at /repo.  Note that the
+# `z` option in the mount of /repo allows it to work on systems with selinux;
+# otherwise the containerized user can't read the directory.
+docker+=(-v "$PWD:/repo:z,ro")
+
+# set $DEPLOYMENT for use in setup.sh
+docker+=(-e DEPLOYMENT="$deployment")
+
+# add arguments based on the deployment (once that deployment is set up)
+case $deployment in
+    taskcluster-staging)
+        docker+=(-e GCLOUD_PROJECT=taskcluster-staging-206320)
+        docker+=(-e GCLOUD_CLUSTER=taskcluster)
+        docker+=(-e GCLOUD_CLUSTER_ZONE=us-east4-a)
+        ;;
+    *)
+        msg warning 'No configuration for this deployment; run terraform in the setup directory'
+        msg warning '  and edit terraform-runner.sh with the results'
+        ;;
+esac
+
+# specify the docker image
+docker+=($docker_image)
+
+msg info "Running docker container"
+${docker[@]}

--- a/terraform-runner/Dockerfile
+++ b/terraform-runner/Dockerfile
@@ -1,0 +1,53 @@
+FROM golang:1.10.3-stretch
+
+# Install terraform + providers, latest versions,
+# then clean up go source (300M) and GOROOT (500M)
+RUN go get github.com/hashicorp/terraform && \
+    go get golang.org/x/tools/cmd/stringer && \
+    cd $GOPATH/src/github.com/hashicorp/terraform && \
+    make dev && \
+    go get -u github.com/ericchiang/terraform-provider-k8s && \
+    go get -u github.com/taskcluster/terraform-provider-jsone && \
+    rm -rf /go/src /usr/local/go
+
+# https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
+RUN apt-get update && \
+    apt-get install apt-transport-https && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > /etc/apt/sources.list.d/azure-cli.list && \
+    curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install azure-cli
+
+# https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
+RUN apt-get install -y python3-pip && \
+    pip3 install awscli
+
+# https://cloud.google.com/sdk/docs/downloads-versioned-archives
+# updated to the latest version, with kubectl
+RUN curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-207.0.0-linux-x86_64.tar.gz | tar -C / -zxf - && \
+    /google-cloud-sdk/install.sh -q && \
+    PATH="${PATH}:/google-cloud-sdk/bin" && \
+    gcloud components install kubectl --quiet && \
+    gcloud components update
+ENV PATH="${PATH}:/google-cloud-sdk/bin"
+
+# install some random stuff
+RUN apt-get install -y jq
+
+# set up a non-root user (as a uid unlikely to match anyone's host userid)
+RUN useradd -u 1500 -m tf
+USER tf
+
+ADD setup.sh /setup.sh
+
+# set up the homedir (as required by terraform-runner.sh)
+RUN echo '. /setup.sh' >> /home/tf/.bashrc && \
+    mkdir -p /home/tf/setup-.terraform && \
+    mkdir -p /home/tf/install-.terraform
+
+# make the home directory a volume, so that it can be persisted
+VOLUME /home/tf
+
+# and make the repository a volume, so that it can be bind-mounted from the outside
+VOLUME /repo
+WORKDIR /repo

--- a/terraform-runner/setup.sh
+++ b/terraform-runner/setup.sh
@@ -1,0 +1,133 @@
+#! /bin/bash
+
+# display a message at a particular level
+msg() {
+    local level="${1}"
+    shift
+
+    local _esc=$'\033'
+    local normal="$_esc[0m"
+
+    case $level in
+        # don't display debug messages unless DEBUG is set
+        debug) [ -z "$DEBUG" ] && return ;;
+        info) local color="$_esc[0;36m" ;;
+        warning) local color="$_esc[1;33m" ;;
+        error) local color="$_esc[1;31m" ;;
+    esac
+
+    echo "$color${@}$normal"
+}
+
+msg info "Setting up credenials to run taskcluster-mozilla-terraform for $DEPLOYMENT"
+msg info "  -- run '. /setup.sh' if necessary to repeat this setup process"
+
+signin-aws() {
+    # reset any existing credentials
+    unset AWS_SESSION_TOKEN
+    unset AWS_SECRET_ACCESS_KEY
+    unset AWS_ACCESS_KEY_ID
+
+    # Expiration time of login session (in seconds)
+    DURATION="21600"  # 6 hours
+
+    # Ask user for token
+    if [[ -z "$TOKEN" ]]; then
+      echo -n "Enter AWS MFA token: "
+      read TOKEN
+    fi
+
+    # Re-export AWS credentials for use in this script, if set
+    if [ -n "$SIGNIN_AWS_ACCESS_KEY_ID" ]; then
+        export AWS_ACCESS_KEY_ID="$SIGNIN_AWS_ACCESS_KEY_ID"
+        export AWS_SECRET_ACCESS_KEY="$SIGNIN_AWS_SECRET_ACCESS_KEY"
+    fi
+
+    msg info "Fetching temporary AWS credentials"
+
+    SERIAL_NUMBER=`aws "${@}" iam list-mfa-devices  | jq -r .MFADevices[0].SerialNumber`
+    if [ -z "$SERIAL_NUMBER" ]; then
+      echo "Could not list MFA devices"
+      return 1
+    fi
+    STS_CREDENTIALS=`aws "${@}" sts get-session-token --serial-number "$SERIAL_NUMBER" --token-code "$TOKEN" --duration-seconds $DURATION`
+    if [ -z "$STS_CREDENTIALS" ]; then
+      echo "Could not get session token"
+      return 1
+    fi
+
+    export AWS_ACCESS_KEY_ID=`echo $STS_CREDENTIALS | jq -r .Credentials.AccessKeyId`
+    export AWS_SECRET_ACCESS_KEY=`echo $STS_CREDENTIALS | jq -r .Credentials.SecretAccessKey`
+    export AWS_SESSION_TOKEN=`echo $STS_CREDENTIALS | jq -r .Credentials.SessionToken`
+}
+
+### Passwordstore
+
+# the terraform-runner.sh script dumps secrets at ~/secrets.sh, so read that if it exists,
+# but remove it immediately.  If it does not exist but there are TF_VAR variables set,
+# that's OK.
+if [ -f "/home/tf/secrets.sh" ]; then
+    msg info "Sourcing secrets.sh"
+    source "/home/tf/secrets.sh"
+else
+    msg info "secrets.sh not found"
+fi
+
+tf_vars=$(python -c 'import os, sys; sys.stdout.write(" ".join(v for v in os.environ if v.startswith("TF_VAR_")))')
+if [ -z "$tf_vars" ]; then
+    msg error 'No TF_VAR secrets are set!'
+    echo "Put the required terraform variables in /home/tf/secrets.sh in this container; easiest is to simply"
+    echo "copy-paste the data from your secret storage."
+    return 1
+fi
+
+### Azure
+
+if [ ! -d ~/.azure ]; then
+    msg warning 'Azure login required'
+    az login
+else
+    msg info 'Refreshing Azure credentials'
+    az account get-access-token | \
+        python -c 'import json, sys; print("  Token expires " + json.load(sys.stdin)["expiresOn"])'
+fi
+msg info 'Azure setup complete'
+
+### AWS
+
+if [ ! -d ~/.aws ]; then
+    msg warning 'AWS is not set up; running `aws configure`..'
+    aws configure
+fi
+if ! aws s3 ls >/dev/null 2>/dev/null; then
+    msg warning 'AWS MFA required'
+    signin-aws || return 1
+fi
+msg info 'AWS setup complete'
+
+### Google Cloud
+
+if ! gcloud auth print-access-token >/dev/null 2>/dev/null; then
+    msg warning 'Google Cloud login required'
+    gcloud auth login
+fi
+if ! gcloud auth application-default print-access-token >/dev/null 2>/dev/null; then
+    msg warning 'Google Cloud ADC login required (yes, sorry, two logins)'
+    gcloud auth application-default login
+fi
+msg info 'Google Cloud setup complete'
+
+### Kubernetes
+
+if [ -n "$GCLOUD_PROJECT" ]; then
+    if ! kubectl get pods >/dev/null 2>&1; then
+        msg debug "setting gcloud project"
+        gcloud config set project "$GCLOUD_PROJECT"
+        msg debug "getting kubectl context"
+        gcloud container clusters get-credentials "$GCLOUD_CLUSTER" --zone "$GCLOUD_CLUSTER_ZONE"
+        # TODO: not sure what to do with the clusterrolebinding??
+    fi
+    msg info 'kubectl context setup complete'
+else
+    msg warning 'No deployment-specific config defined in terraform-runner.sh; not setting up kubectl'
+fi


### PR DESCRIPTION
This encapsulates a bunch of tricky steps that might otherwise be
impediments to using Terraform:

* the build process for terraform and its plugins
* installation of multiple cloud CLIs
* authentication to multiple clouds
* deployment secrets
* kubernetes setup

---

@petemoore could you try this out to see if it works for you?  There may be a few docker-on-macOS issues to sort out, but we can do those on a subsequent PR.

@imbstack what are your thoughts on the security issues here?  We basically have a docker volume -- easily accssible by anyone on the host with docker access -- that contains admin credentials to all three clouds and (momentarily) all of our deployment secrets, in cleartext.  That doesn't sound too bad, right?