### PR TITLE
Add audit logs support

### DIFF
--- a/install/audit-logs.tf
+++ b/install/audit-logs.tf
@@ -1,0 +1,95 @@
+resource "aws_s3_bucket" "taskcluster_audit_logs" {
+  bucket = "taskcluster-staging-audit-logs"
+}
+
+resource "aws_kinesis_stream" "taskcluster_audit_logs" {
+  name             = "taskcluster-staging-audit-logs"
+  shard_count      = 1
+  retention_period = 24
+}
+
+resource "aws_iam_role" "taskcluster_audit_logs_firehose" {
+  name = "taskcluster-audit-log-firehose-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "firehose.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "${var.aws_account}"
+        }
+      }
+    } ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "taskcluster_audit_logs_firehose" {
+  name = "taskcluster-audit-logs-firehose"
+  role = "${aws_iam_role.taskcluster_audit_logs_firehose.name}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement":
+    [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:AbortMultipartUpload",
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.taskcluster_audit_logs.arn}",
+                "${aws_s3_bucket.taskcluster_audit_logs.arn}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kinesis:DescribeStream",
+                "kinesis:GetShardIterator",
+                "kinesis:GetRecords"
+            ],
+            "Resource": "${aws_kinesis_stream.taskcluster_audit_logs.arn}"
+        },
+        {
+           "Effect": "Allow",
+           "Action": [
+               "logs:PutLogEvents"
+           ],
+           "Resource": [
+               "arn:aws:logs:*:${var.aws_account}:log-group:/aws/kinesisfirehose/taskcluster-audit-logs:log-stream:*"
+           ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "taskcluster_audit_logs_firehose" {
+  name        = "taskcluster-audit-logs"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = "${aws_iam_role.taskcluster_audit_logs_firehose.arn}"
+    bucket_arn = "${aws_s3_bucket.taskcluster_audit_logs.arn}"
+    prefix     = "auth-audit-logs"
+
+    cloudwatch_logging_options = {
+      enabled = true
+    }
+  }
+}

--- a/install/main.tf
+++ b/install/main.tf
@@ -40,4 +40,8 @@ module "taskcluster" {
   irc_server                = "${var.irc_server}"
   irc_port                  = "${var.irc_port}"
   irc_password              = "${var.irc_password}"
+  github_integration_id     = "${var.github_integration_id}"
+  github_oauth_token        = "${var.github_oauth_token}"
+  github_private_pem        = "${var.github_private_pem}"
+  github_webhook_secret     = "${var.github_webhook_secret}"
 }

--- a/install/variables.tf
+++ b/install/variables.tf
@@ -126,6 +126,26 @@ variable "irc_password" {
   description = "password for irc bot."
 }
 
+variable "github_integration_id" {
+  type        = "string"
+  description = "taskcluster-github app integration id."
+}
+
+variable "github_oauth_token" {
+  type        = "string"
+  description = "taskcluster-github app oauth token."
+}
+
+variable "github_private_pem" {
+  type        = "string"
+  description = "taskcluster-github private pem."
+}
+
+variable "github_webhook_secret" {
+  type        = "string"
+  description = "taskcluster-github webhook secret."
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.


### PR DESCRIPTION
This is the _new_ way we plan to do it in production rather than the old way. This has a level of indirection through kinesis data streams rather than right into firehose so that we can peel off logs and send them to other teams.