### PR TITLE
Bug 1498700 - use a different vhost for each deployment

### DIFF
--- a/deployments/bstack-dev/main.sh
+++ b/deployments/bstack-dev/main.sh
@@ -9,7 +9,6 @@ setup-variables() {
     export TF_VAR_rabbitmq_hostname="hip-macaw.rmq.cloudamqp.com"
     export TF_VAR_rabbitmq_username="pvigqwpo"
     export TF_VAR_rabbitmq_password="$(get-secret rabbitmq_password)"
-    export TF_VAR_rabbitmq_vhost="/"
 
     export TF_VAR_root_url="https://taskcluster.imbstack.com"
 

--- a/deployments/dustin-dev/main.sh
+++ b/deployments/dustin-dev/main.sh
@@ -9,7 +9,6 @@ setup-variables() {
     export TF_VAR_rabbitmq_hostname="hip-macaw.rmq.cloudamqp.com"
     export TF_VAR_rabbitmq_username="pvigqwpo"
     export TF_VAR_rabbitmq_password="$(get-secret rabbitmq_password)"
-    export TF_VAR_rabbitmq_vhost="/"
 
     export TF_VAR_gcp_project="dustin-dev-2"
 

--- a/deployments/lib/variables.sh
+++ b/deployments/lib/variables.sh
@@ -20,6 +20,10 @@ setup-common-variables() {
     export TF_VAR_gcp_region="us-east1"
     export TF_VAR_gcp_folder_id="944037250603"
 
+    ## RabbitMQ
+
+    export TF_VAR_rabbitmq_vhost="${DPL}"
+
     ## Kubernetes
 
     export TF_VAR_kubernetes_cluster_name=taskcluster

--- a/deployments/owlish-dev/main.sh
+++ b/deployments/owlish-dev/main.sh
@@ -9,7 +9,6 @@ setup-variables() {
     export TF_VAR_rabbitmq_hostname="hip-macaw.rmq.cloudamqp.com"
     export TF_VAR_rabbitmq_username="pvigqwpo"
     export TF_VAR_rabbitmq_password="$(get-secret rabbitmq_password)"
-    export TF_VAR_rabbitmq_vhost="/"
 
     export TF_VAR_root_url="https://owlish.imbstack.com"
 

--- a/tf/taskcluster/main.tf
+++ b/tf/taskcluster/main.tf
@@ -4,7 +4,7 @@ module "taskcluster" {
   azure_region          = "${var.azure_region}"
   root_url              = "${var.root_url}"
   rabbitmq_hostname     = "${var.rabbitmq_hostname}"
-  rabbitmq_vhost        = "${var.rabbitmq_vhost}"
+  rabbitmq_vhost        = "${rabbitmq_vhost.vhost.name}"
   disabled_services     = ["taskcluster-ping"]
   cluster_name          = "${var.cluster_name}"
   notify_ses_arn        = "${var.notify_ses_arn}"

--- a/tf/taskcluster/rabbitmq.tf
+++ b/tf/taskcluster/rabbitmq.tf
@@ -1,0 +1,4 @@
+resource "rabbitmq_vhost" "vhost" {
+  name = "${var.rabbitmq_vhost}"
+}
+


### PR DESCRIPTION
I *think* that the reference to `${rabbitmq_vhost.vhost.name}` will order dependencies properly here.  But who knows.