### PR TITLE
Bug 1501843 - re-source everything into the shell on `setup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ You must install submodules with `git submodule init` and `git submodule update`
 
 ### Changing Settings
 
-If you change settings in a deployment configuration file, simply exit the Docker container and re-start it.
-Similarly, if your cloud credentials expire, exit the container and re-start it.
+If you change settings in a deployment configuration file, simply run `setup` again in the docker container.
+Similarly, if your cloud credentials expire, run `setup`.
 
 If you need to change secrets, you can edit the file within the docker container at `~/secrets.sh`.
+Be sure to keep this in sync with the file in passwordstore.
 
 If you need to change credentials (perhaps you signed into the wrong AWS account?), follow the `docker volume rm` steps above.
 

--- a/deployments/lib/secrets.sh
+++ b/deployments/lib/secrets.sh
@@ -14,6 +14,7 @@ get-secret() {
 }
 
 setup-secrets() {
+    SECRETS=()
     if [ -f "/home/tf/secrets.sh" ]; then
         msg info "Sourcing secrets.sh"
         source "/home/tf/secrets.sh"

--- a/deployments/lib/variables.sh
+++ b/deployments/lib/variables.sh
@@ -1,3 +1,10 @@
+clean-variables() {
+    # clear all TF_VAR_* exports
+    for v in `export | grep TF_VAR_ | cut -d' ' -f 3 | cut -d= -f 1`; do
+        eval "unset $v"
+    done
+}
+
 setup-common-variables() {
     # pass DEPLOYMENT and DPL along to Terraform directly
     export TF_VAR_deployment="${DEPLOYMENT}"

--- a/deployments/setup.sh
+++ b/deployments/setup.sh
@@ -33,17 +33,20 @@ fi
 
 PS1="${DPL}:\w\$ "
 
+setup-secrets
+clean-variables
+setup-variables  # defined by the deployment
+check-variables
+setup-terraform
+setup-azure
+setup-aws
+setup-gcloud
+setup-kube
+
+# a shell function that will re-run this whole thing (by simply re-sourcing it)
 setup() {
-    setup-secrets
-    setup-variables  # defined by the deployment
-    check-variables
-    setup-terraform
-    setup-azure
-    setup-aws
-    setup-gcloud
-    setup-kube
+    source /repo/deployments/setup.sh
 }
 
-setup
 
 cd /repo/tf


### PR DESCRIPTION
This should eliminate cases where exiting the container and re-running
`./terraform-runner.sh` is required.