### PR TITLE
Bug 1502508 - use correct role name

### DIFF
--- a/tf/taskcluster/ingress_controller/role_binding.yaml
+++ b/tf/taskcluster/ingress_controller/role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: ingress-controller
+  name: nginx-ingress-role
 subjects:
   - kind: ServiceAccount
     name: ingress-controller


### PR DESCRIPTION
This fixes the controller complaining about not having access to its
leader-election ConfigMap.