### PR TITLE
Bug 1519848 - upgrade to cert-manager@0.5.2

### DIFF
--- a/tf/taskcluster/cert_manager/certificate_crd.yaml
+++ b/tf/taskcluster/cert_manager/certificate_crd.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/tf/taskcluster/cert_manager/clusterissuer_crd.yaml
+++ b/tf/taskcluster/cert_manager/clusterissuer_crd.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/912c7672bd3e6ba1e7ef9dff48083ee6f3d6cbab/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.1
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/tf/taskcluster/cert_manager/clusterrole.yaml
+++ b/tf/taskcluster/cert_manager/clusterrole.yaml
@@ -1,11 +1,11 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 rules:

--- a/tf/taskcluster/cert_manager/clusterrolebinding.yaml
+++ b/tf/taskcluster/cert_manager/clusterrolebinding.yaml
@@ -1,11 +1,11 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/tf/taskcluster/cert_manager/deployment.yaml
+++ b/tf/taskcluster/cert_manager/deployment.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -6,7 +6,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.5.2"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/tf/taskcluster/cert_manager/issuer_crd.yaml
+++ b/tf/taskcluster/cert_manager/issuer_crd.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/tf/taskcluster/cert_manager/namespace.yaml
+++ b/tf/taskcluster/cert_manager/namespace.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/tf/taskcluster/cert_manager/serviceaccount.yaml
+++ b/tf/taskcluster/cert_manager/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/jetstack/cert-manager/blob/v0.5.0/contrib/manifests/cert-manager/with-rbac.yaml
+# From https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,6 +6,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.2
     release: cert-manager
     heritage: Tiller


### PR DESCRIPTION
All resources re-copied from
  https://github.com/jetstack/cert-manager/blob/v0.5.2/contrib/manifests/cert-manager/with-rbac.yaml
but it turns out the only changes were to the version number..

@owlishDeveloper  my renewal is complete, so I can't really test this any more than seeing that it runs and decides it doesn't need to do a renewal.  Can you give it a try on your dev environment?