### PR TITLE
Bug 1503076 - upgrade to Terraform 0.11.11

### DIFF
--- a/terraform-runner.sh
+++ b/terraform-runner.sh
@@ -7,7 +7,7 @@ if [ ! -f util/msg.sh ]; then
 fi
 source util/msg.sh
 
-docker_image="docker.io/taskcluster/terraform-runner:latest@sha256:b6e6afcd61f031c67d82281d14a58fbf6dab9409c4dca4401e93bfefa147e16a"
+docker_image="docker.io/taskcluster/terraform-runner:latest@sha256:4256863f86b7ee68cad3c1dd727eedf8950dca3b4d62cedda870e87fcb3bd966"
 deployment="$1"
 
 if [ -z "$deployment" ] || [ ! -f terraform-runner.sh ]; then

--- a/terraform-runner/Dockerfile
+++ b/terraform-runner/Dockerfile
@@ -1,25 +1,39 @@
-FROM golang:1.10.3-stretch
+FROM golang:1.11-stretch as plugins
 
-# Install terraform + providers, latest versions,
-# then clean up go source (300M) and GOROOT (500M)
-# Note that terraform build fails on non-fmt'd code, but
-# very often the latest code is not correctly formatted.
-RUN go get github.com/hashicorp/terraform && \
+# Install terraform providers (but not terraform, due to the -d), at latest
+# versions.  This uses the very latest terraform, as well, but note that it
+# is not even compiled -- just available in the GOPATH.
+RUN go get -d github.com/hashicorp/terraform && \
     go get golang.org/x/tools/cmd/stringer && \
-    cd $GOPATH/src/github.com/hashicorp/terraform && \
-    make fmt && \
-    make dev && \
-    go get -u github.com/ericchiang/terraform-provider-k8s && \
-    go get -u github.com/taskcluster/terraform-provider-jsone && \
-    rm -rf /go/src /usr/local/go
+    go get github.com/ericchiang/terraform-provider-k8s && \
+    go get github.com/taskcluster/terraform-provider-jsone
+
+FROM debian:stretch
+
+# install some random stuff
+RUN apt-get update && apt-get install -y \
+    jq \
+    vim \
+    nano \
+    less \
+    curl \
+    unzip \
+    gnupg2 \
+    python \
+    python3
+
+# install terraform (change the version number here to use a different version)
+RUN curl -o /terraform.zip https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip && \
+    cd /usr/bin/ && \
+    unzip /terraform.zip && \
+    rm -f /terraform.zip
 
 # https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest
-RUN apt-get update && \
-    apt-get install apt-transport-https && \
+RUN apt-get install -y apt-transport-https && \
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > /etc/apt/sources.list.d/azure-cli.list && \
     curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
     apt-get update && \
-    apt-get install azure-cli
+    apt-get install -y azure-cli
 
 # https://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
 RUN apt-get install -y python3-pip && \
@@ -34,13 +48,6 @@ RUN curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
     gcloud components update
 ENV PATH="${PATH}:/google-cloud-sdk/bin"
 
-# install some random stuff
-RUN apt-get install -y \
-    jq \
-    vim \
-    nano \
-    less
-
 # set up a non-root user (as a uid unlikely to match anyone's host userid)
 RUN useradd -u 1500 -m tf
 USER tf
@@ -48,7 +55,11 @@ USER tf
 # set up the homedir (as required by terraform-runner.sh)
 RUN echo '. /repo/deployments/setup.sh' >> /home/tf/.bashrc && \
     mkdir -p /home/tf/setup-.terraform && \
-    mkdir -p /home/tf/install-.terraform
+    mkdir -p /home/tf/install-.terraform && \
+    mkdir -p /home/tf/.terraform.d/plugins
+
+# copy the plugins in from the earlier build, to the same directory as the terraform binary
+COPY --from=plugins /go/bin/terraform-provider-k8s /go/bin/terraform-provider-jsone /usr/bin/
 
 # make the home directory a volume, so that it can be persisted
 VOLUME /home/tf


### PR DESCRIPTION
This uses an upstream build of terraform, pulling the source only to
build the plugins.

The plugins are stored within the home directory, so old docker volumes
will no longer work -- so add a check and error out in that case.