### PR TITLE
Bug 1522675 - use a container with "native vpc" / "ip aliases"

### DIFF
--- a/deployments/lib/variables.sh
+++ b/deployments/lib/variables.sh
@@ -27,6 +27,8 @@ setup-common-variables() {
     export TF_VAR_gcp_region="us-east1"
     export TF_VAR_gcp_folder_id="944037250603"
 
+    export TF_VAR_gce_provider_image_name="none"
+
     ## RabbitMQ
 
     export TF_VAR_rabbitmq_vhost="${DPL}"

--- a/terraform-runner.sh
+++ b/terraform-runner.sh
@@ -7,7 +7,7 @@ if [ ! -f util/msg.sh ]; then
 fi
 source util/msg.sh
 
-docker_image="docker.io/taskcluster/terraform-runner:latest@sha256:4256863f86b7ee68cad3c1dd727eedf8950dca3b4d62cedda870e87fcb3bd966"
+docker_image="docker.io/taskcluster/terraform-runner:latest@sha256:e204d707334763b18c2b694d4d63b9914b02e4138be5b96aea98000dfc382236"
 deployment="$1"
 
 if [ -z "$deployment" ] || [ ! -f terraform-runner.sh ]; then

--- a/tf/gke/container-cluster.tf
+++ b/tf/gke/container-cluster.tf
@@ -68,6 +68,11 @@ resource "google_container_cluster" "primary" {
   provisioner "local-exec" {
     command = "gcloud container clusters get-credentials ${var.kubernetes_cluster_name} --project ${google_project.project.id} --region ${var.gcp_region}"
   }
+
+  // enable "native VPC" / "alias IPs"
+  ip_allocation_policy {
+    create_subnetwork = true
+  }
 }
 
 resource "k8s_manifest" "admin_bindings" {

--- a/tf/providers.tf.in
+++ b/tf/providers.tf.in
@@ -11,7 +11,7 @@ provider "azurerm" {
 }
 
 provider "google" {
-  version = "~> 1.17.1"
+  version = "~> 1.20.0"
   project = "${var.gcp_project}"
   region  = "${var.gcp_region}"
 }

--- a/tf/taskcluster/ingress_controller.tf
+++ b/tf/taskcluster/ingress_controller.tf
@@ -155,7 +155,7 @@ resource "k8s_manifest" "ingress_controller_certificate" {
   content = "${data.jsone_template.ingress_controller_certificate.rendered}"
 
   depends_on = [
-    "k8s_manifest.cert_manager_clusterissuer_crd",
+    "k8s_manifest.cert_manager_certificate_crd",
     "k8s_manifest.ingress_controller_namespace",
   ]
 }


### PR DESCRIPTION
Accessing other GCP resources from within a GKE cluster, without using
public IPs, requires that the GKE cluster have native VPC support
enabled.  Basically, that means that the Kubernetes resources operate in
the same networking environment as the rest of GCP and thus traffic can 
be routed to other GCP resources.  Such as Cloud SQL DBs.

The key change here is in `tf/gke/container-cluster.tf`, where the 
configuration of `ip_allocation_policy` forces use of a native VPC.

This parameter requires a newer version of the google provider.

While setting this up, it transpires that we are all naming our 
cloudwatch streams the same thing, so I added the deployment name there.
It also seems that there was a bug in the cert-manager dependencies, so
that is fixed as well.
