### PR TITLE
The code requires `providerType` field

### DIFF
--- a/tf/taskcluster/wm-providers.tf
+++ b/tf/taskcluster/wm-providers.tf
@@ -31,7 +31,7 @@ resource "google_service_account_key" "wm-key" {
 locals {
   wm_providers = {
     google = {
-      implementation      = "google"
+      providerType        = "google"
       project             = "${var.gcp_project}"
       instancePermissions = ["logging.logEntries.create"]
       creds               = "${google_service_account_key.wm-key.private_key}"


### PR DESCRIPTION
I was deploying today, and was getting errors - it seems when we renamed things we forgot to rename this as well